### PR TITLE
Add support for Expansion Valve

### DIFF
--- a/HeishaMon/decode.h
+++ b/HeishaMon/decode.h
@@ -42,7 +42,7 @@ static const char _unknown[] PROGMEM = "unknown";
 
 
 
-#define NUMBER_OF_TOPICS 142 //last topic number + 1
+#define NUMBER_OF_TOPICS 143 //last topic number + 1
 #define NUMBER_OF_TOPICS_EXTRA 6 //last topic number + 1
 #define NUMBER_OF_OPT_TOPICS 7 //last topic number + 1
 #define MAX_TOPIC_LEN 42 // max length + 1
@@ -218,6 +218,7 @@ static const char topics[][MAX_TOPIC_LEN] PROGMEM = {
   "Heating_Control",         //TOP139
   "Smart_DHW",               //TOP140
   "Quiet_Mode_Priority",     //TOP141
+  "Expansion_Valve",         //TOP142
 };
 
 static const byte topicBytes[] PROGMEM = { //can store the index as byte (8-bit unsigned humber) as there aren't more then 255 bytes (actually only 203 bytes) to decode
@@ -363,6 +364,7 @@ static const byte topicBytes[] PROGMEM = { //can store the index as byte (8-bit 
   30,    //TOP139
   24,    //TOP140
   11,    //TOP141
+  175,   //TOP142
 };
 
 
@@ -520,6 +522,7 @@ static const topicFP topicFunctions[] PROGMEM = {
   getBit5and6,       //TOP139
   getBit1and2,       //TOP140
   getBit3and4,       //TOP141
+  getIntMinus1,      //TOP142
 };
 
 static const char *DisabledEnabled[] PROGMEM = {"2", "Disabled", "Enabled"};
@@ -560,6 +563,7 @@ static const char *Model[] PROGMEM = {"0", "Model"};
 static const char *HeatingControl[] PROGMEM = {"2", "Comfort", "Efficiency"};
 static const char *SmartDHW[] PROGMEM = {"2", "Variable", "Standard"};
 static const char *QuietModePriority[] PROGMEM = {"2", "Sound", "Capacity"};
+static const char *Steps[] PROGMEM = {"0", "Steps"};
 
 static const char **opttopicDescription[] PROGMEM = {
   OffOn,          //OPT0
@@ -723,4 +727,5 @@ static const char **topicDescription[] PROGMEM = {
   HeatingControl,  //TOP139
   SmartDHW,        //TOP140
   QuietModePriority, //TOP141
+  Steps,             //TOP142
 };

--- a/MQTT-Topics.md
+++ b/MQTT-Topics.md
@@ -158,6 +158,7 @@ TOP138 | main/Bivalent_Advanced_DHW_Delay	 | Bivalent adv. par. DHW delay
 TOP139 | main/Heating_Control | Heating Control
 TOP140 | main/Smart_DHW | Smart DHW
 TOP141 | main/Quiet_Mode_Priority | Quiet Mode Priority (0=sound, 1=capacity)
+TOP142 | main/Expansion_Valve | Expansion Valve (Steps)
 
 
 

--- a/ProtocolByteDecrypt.md
+++ b/ProtocolByteDecrypt.md
@@ -177,7 +177,7 @@
 |  TOP93 | 172 | 51 | Convert to DEC X-1   | Pump Duty [duty] |
 |  TOP62 | 173 | 59 | Convert to DEC (X-1) X10  | Fan 1 Motor Speed [R/Min] |
 |  TOP63 | 174 | 01 | Convert to DEC (X-1) X10  | Fan 2 Motor Speed [R/Min] |
-|  TOP | 175 | 36 | Convert to DEC -1  | ?Possible EEV valve (PID) |
+|  TOP142 | 175 | 36 | Convert to DEC -1  | Expansion Valve [Steps] |
 |  TOP | 176 | 79 | Convert to DEC -1  | ?Possible ByPass valve |
 |  TOP127 | 177 | 01 | Convert to DEC -1  | 2 Zone mixing valve PID |
 |  TOP128 | 178 | 01 | Convert to DEC -1  | 1 Zone mixing valve PID |


### PR DESCRIPTION
I've added support for the expansion valve after me and some other folks (thanks to them!) verified that it actually is it using external measurement probes on the EEV wires:

<img width="360" height="174" alt="image" src="https://github.com/user-attachments/assets/b2fe2565-1b9b-46c4-949d-df2ab8fb30a0" />