### PR TITLE
Add DHW sensor selection read topic and SET command

### DIFF
--- a/HeishaMon/commands.cpp
+++ b/HeishaMon/commands.cpp
@@ -966,6 +966,29 @@ unsigned int set_pump_flowrate_mode(char *msg, unsigned char *cmd, char *log_msg
   return sizeof(panasonicSendQuery);
 }
 
+unsigned int set_dhw_sensor_selection(char *msg, unsigned char *cmd, char *log_msg) {
+
+  const byte address = 11;
+  byte value = 0b01;
+
+  if ( String(msg).toInt() == 1 ) {
+    value = 0b10;
+  }
+
+  {
+    char tmp[256] = { 0 };
+    snprintf_P(tmp, 255, PSTR("set dhw sensor selection %d"), value - 1);
+    memcpy(log_msg, tmp, sizeof(tmp));
+  }
+
+  {
+    memcpy_P(cmd, panasonicSendQuery, sizeof(panasonicSendQuery));
+    cmd[address] = value;
+  }
+
+  return sizeof(panasonicSendQuery);
+}
+
 unsigned int set_external_compressor_control(char *msg, unsigned char *cmd, char *log_msg){
   const byte off_state=64;
   const byte address=23;

--- a/HeishaMon/commands.h
+++ b/HeishaMon/commands.h
@@ -70,6 +70,7 @@ unsigned int set_heatingcontrol(char *msg, unsigned char *cmd, char *log_msg);
 unsigned int set_smart_dhw(char *msg, unsigned char *cmd, char *log_msg);
 unsigned int set_quiet_mode_priority(char *msg, unsigned char *cmd, char *log_msg);
 unsigned int set_pump_flowrate_mode(char *msg, unsigned char *cmd, char *log_msg);
+unsigned int set_dhw_sensor_selection(char *msg, unsigned char *cmd, char *log_msg);
 
 
 //optional pcb commands
@@ -162,6 +163,7 @@ const cmdStruct commands[] PROGMEM = {
   { "SetSmartDHW", set_smart_dhw },
   { "SetQuietModePriority", set_quiet_mode_priority },
   { "SetPumpFlowrateMode", set_pump_flowrate_mode },
+  { "SetDHWSensorSelection", set_dhw_sensor_selection },
 };
 
 struct optCmdStruct{

--- a/HeishaMon/decode.h
+++ b/HeishaMon/decode.h
@@ -42,7 +42,7 @@ static const char _unknown[] PROGMEM = "unknown";
 
 
 
-#define NUMBER_OF_TOPICS 143 //last topic number + 1
+#define NUMBER_OF_TOPICS 144 //last topic number + 1
 #define NUMBER_OF_TOPICS_EXTRA 6 //last topic number + 1
 #define NUMBER_OF_OPT_TOPICS 7 //last topic number + 1
 #define MAX_TOPIC_LEN 42 // max length + 1
@@ -219,6 +219,7 @@ static const char topics[][MAX_TOPIC_LEN] PROGMEM = {
   "Smart_DHW",               //TOP140
   "Quiet_Mode_Priority",     //TOP141
   "Expansion_Valve",         //TOP142
+  "DHW_Sensor_Selection",    //TOP143
 };
 
 static const byte topicBytes[] PROGMEM = { //can store the index as byte (8-bit unsigned humber) as there aren't more then 255 bytes (actually only 203 bytes) to decode
@@ -365,6 +366,7 @@ static const byte topicBytes[] PROGMEM = { //can store the index as byte (8-bit 
   24,    //TOP140
   11,    //TOP141
   175,   //TOP142
+  11,    //TOP143
 };
 
 
@@ -523,6 +525,7 @@ static const topicFP topicFunctions[] PROGMEM = {
   getBit1and2,       //TOP140
   getBit3and4,       //TOP141
   getIntMinus1,      //TOP142
+  getBit7and8,       //TOP143
 };
 
 static const char *DisabledEnabled[] PROGMEM = {"2", "Disabled", "Enabled"};
@@ -563,6 +566,7 @@ static const char *Model[] PROGMEM = {"0", "Model"};
 static const char *HeatingControl[] PROGMEM = {"2", "Comfort", "Efficiency"};
 static const char *SmartDHW[] PROGMEM = {"2", "Variable", "Standard"};
 static const char *QuietModePriority[] PROGMEM = {"2", "Sound", "Capacity"};
+static const char *DHWSensorType[] PROGMEM = {"2", "Top", "Center"};
 static const char *Steps[] PROGMEM = {"0", "Steps"};
 
 static const char **opttopicDescription[] PROGMEM = {
@@ -728,4 +732,5 @@ static const char **topicDescription[] PROGMEM = {
   SmartDHW,        //TOP140
   QuietModePriority, //TOP141
   Steps,             //TOP142
+  DHWSensorType,     //TOP143
 };

--- a/MQTT-Topics.md
+++ b/MQTT-Topics.md
@@ -159,6 +159,7 @@ TOP139 | main/Heating_Control | Heating Control
 TOP140 | main/Smart_DHW | Smart DHW
 TOP141 | main/Quiet_Mode_Priority | Quiet Mode Priority (0=sound, 1=capacity)
 TOP142 | main/Expansion_Valve | Expansion Valve (Steps)
+TOP143 | main/DHW_Sensor_Selection | DHW tank sensor selection (0=Top, 1=Center) (K/L series All-In-One only)
 
 
 
@@ -230,6 +231,7 @@ SET39 | SetHeatingControl | Set heating control | 0=comfort, 1=efficiency
 SET40 | SetSmartDHW | Set SmartDHW | 0=variable, 1=standard
 SET41 | SetQuietModePriority | Set Quiet Mode Priority | 0=sound, 1=capacity
 SET42 | SetPumpFlowrateMode | Set Pump Flowrate Mode | 0=deltaT, 1=max. duty
+SET43 | SetDHWSensorSelection | Set DHW tank sensor selection (K/L series All-In-One only) | 0=Top, 1=Center
 
 *If you operate your heatpump in water mode with direct temperature setup: topics ending xxxRequestTemperature will set the absolute target temperature.*
 

--- a/ProtocolByteDecrypt.md
+++ b/ProtocolByteDecrypt.md
@@ -13,7 +13,7 @@
 |  TOP | 08 | 00 |   | 0 byte |
 |  TOP58+TOP59 | 09 | 05 | 3rd & 4th bit = b01 Standard, b10 - DHW Standard/Variable (J-series only)<br/>5th & 6th bit = b01 DHW heater off, b10 - DHW heater on<br/>7rd & 8th bit = b01 Water heater off, b10 - Water heater on | DHW capacity (J-series only)<br/>Heaters enable allowed status|
 |  TOP | 10 | 00 |   | 0 byte |
-|  TOP141 | 11 | 00 | 3rd & 4th bit = b01 - Sound , b10 - Capacity <br/> 7th & 8th bit = b01 - DHW Top sensor , b10 - DHW Center Sensor | Quiet Mode Priority (K/L series) <br/> Only All-In-One |
+|  TOP141+TOP143 | 11 | 00 | 3rd & 4th bit = b01 - Sound , b10 - Capacity <br/> 7th & 8th bit = b01 - DHW Top sensor , b10 - DHW Center Sensor | Quiet Mode Priority (K/L series) <br/> DHW Sensor Selection (K/L series All-In-One only) |
 |  TOP | 12 | 00 |   | 0 byte |
 |  TOP | 13 | 00 |   | 0 byte |
 |  TOP | 14 | 00 |   | 0 byte |


### PR DESCRIPTION
## Summary

- Adds a new read topic **TOP143** (`DHW_Sensor_Selection`) that decodes byte 11, bits 7-8, reporting which DHW tank sensor is active (0 = Top, 1 = Center)
- Adds a new SET command **SetDHWSensorSelection** (SET43) to switch between Top and Center DHW tank sensors via MQTT
- Updates `MQTT-Topics.md` and `ProtocolByteDecrypt.md` documentation accordingly

This is applicable to **K/L series All-In-One units only**, where the DHW tank has both a top and center temperature sensor. The byte 11 bits 7-8 layout was already documented in `ProtocolByteDecrypt.md` but had no corresponding read topic or SET command.

## Changes

| File | Change |
|------|--------|
| `HeishaMon/decode.h` | Added TOP143 entry to `topics[]`, `topicBytes[]` (byte 11), `topicFunctions[]` (`getBit7and8`), `topicDescription[]` (`DHWSensorType`), and incremented `NUMBER_OF_TOPICS` to 144 |
| `HeishaMon/commands.h` | Added `set_dhw_sensor_selection` declaration and `SetDHWSensorSelection` entry in `commands[]` array |
| `HeishaMon/commands.cpp` | Added `set_dhw_sensor_selection()` implementation (writes to byte 11, bits 7-8: 0b01 = Top, 0b10 = Center) |
| `MQTT-Topics.md` | Added TOP143 sensor topic and SET43 command documentation |
| `ProtocolByteDecrypt.md` | Updated byte 11 reference to include TOP143 |