### PR TITLE
Add DHW and Room Heater State SET commands

### DIFF
--- a/HeishaMon/commands.cpp
+++ b/HeishaMon/commands.cpp
@@ -989,6 +989,52 @@ unsigned int set_dhw_sensor_selection(char *msg, unsigned char *cmd, char *log_m
   return sizeof(panasonicSendQuery);
 }
 
+unsigned int set_dhw_heater_state(char *msg, unsigned char *cmd, char *log_msg) {
+
+  const byte address = 9;
+  byte value = 0b01;
+
+  if ( String(msg).toInt() == 1 ) {
+    value = 0b10;
+  }
+
+  {
+    char tmp[256] = { 0 };
+    snprintf_P(tmp, 255, PSTR("set dhw heater state %d"), value - 1);
+    memcpy(log_msg, tmp, sizeof(tmp));
+  }
+
+  {
+    memcpy_P(cmd, panasonicSendQuery, sizeof(panasonicSendQuery));
+    cmd[address] = value << 2;
+  }
+
+  return sizeof(panasonicSendQuery);
+}
+
+unsigned int set_room_heater_state(char *msg, unsigned char *cmd, char *log_msg) {
+
+  const byte address = 9;
+  byte value = 0b01;
+
+  if ( String(msg).toInt() == 1 ) {
+    value = 0b10;
+  }
+
+  {
+    char tmp[256] = { 0 };
+    snprintf_P(tmp, 255, PSTR("set room heater state %d"), value - 1);
+    memcpy(log_msg, tmp, sizeof(tmp));
+  }
+
+  {
+    memcpy_P(cmd, panasonicSendQuery, sizeof(panasonicSendQuery));
+    cmd[address] = value;
+  }
+
+  return sizeof(panasonicSendQuery);
+}
+
 unsigned int set_external_compressor_control(char *msg, unsigned char *cmd, char *log_msg){
   const byte off_state=64;
   const byte address=23;

--- a/HeishaMon/commands.h
+++ b/HeishaMon/commands.h
@@ -71,6 +71,8 @@ unsigned int set_smart_dhw(char *msg, unsigned char *cmd, char *log_msg);
 unsigned int set_quiet_mode_priority(char *msg, unsigned char *cmd, char *log_msg);
 unsigned int set_pump_flowrate_mode(char *msg, unsigned char *cmd, char *log_msg);
 unsigned int set_dhw_sensor_selection(char *msg, unsigned char *cmd, char *log_msg);
+unsigned int set_dhw_heater_state(char *msg, unsigned char *cmd, char *log_msg);
+unsigned int set_room_heater_state(char *msg, unsigned char *cmd, char *log_msg);
 
 
 //optional pcb commands
@@ -164,6 +166,8 @@ const cmdStruct commands[] PROGMEM = {
   { "SetQuietModePriority", set_quiet_mode_priority },
   { "SetPumpFlowrateMode", set_pump_flowrate_mode },
   { "SetDHWSensorSelection", set_dhw_sensor_selection },
+  { "SetDHWHeaterState", set_dhw_heater_state },
+  { "SetRoomHeaterState", set_room_heater_state },
 };
 
 struct optCmdStruct{

--- a/MQTT-Topics.md
+++ b/MQTT-Topics.md
@@ -232,6 +232,8 @@ SET40 | SetSmartDHW | Set SmartDHW | 0=variable, 1=standard
 SET41 | SetQuietModePriority | Set Quiet Mode Priority | 0=sound, 1=capacity
 SET42 | SetPumpFlowrateMode | Set Pump Flowrate Mode | 0=deltaT, 1=max. duty
 SET43 | SetDHWSensorSelection | Set DHW tank sensor selection (K/L series All-In-One only) | 0=Top, 1=Center
+SET44 | SetDHWHeaterState | Allow DHW backup/booster heater | 0=blocked, 1=free
+SET45 | SetRoomHeaterState | Allow Room backup/booster heater | 0=blocked, 1=free
 
 *If you operate your heatpump in water mode with direct temperature setup: topics ending xxxRequestTemperature will set the absolute target temperature.*
 


### PR DESCRIPTION
### Summary

- Adds new command topics to control heater “allowed” flags that are currently exposed as readonly sensor topics:
  - SetDHWHeaterState (maps to TOP58 main/DHW_Heater_State)
  - SetRoomHeaterState (maps to TOP59 main/Room_Heater_State)
- Implements the corresponding command handlers in HeishaMon/commands.cpp and registers them in HeishaMon/commands.h.
- Updates MQTT-Topics.md with new command documentation (SET44/SET45).
### Details
- Both commands write to byte 9 of the Panasonic command datagram:
  - DHW heater allowed state uses bits 5&6 (shifted by 2)
  - Room heater allowed state uses bits 7&8 (lower 2 bits)
- Values follow existing convention: 0=blocked, 1=free.